### PR TITLE
Jakarta EE 対応

### DIFF
--- a/src/test/java/nablarch/fw/action/Hoge.java
+++ b/src/test/java/nablarch/fw/action/Hoge.java
@@ -1,9 +1,9 @@
 package nablarch.fw.action;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "HOGE")

--- a/src/test/java/nablarch/fw/action/TestBatchRequest.java
+++ b/src/test/java/nablarch/fw/action/TestBatchRequest.java
@@ -1,9 +1,9 @@
 package nablarch.fw.action;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * テストバッチリクエスト

--- a/src/test/java/nablarch/fw/action/TestBatchRequest2.java
+++ b/src/test/java/nablarch/fw/action/TestBatchRequest2.java
@@ -1,9 +1,9 @@
 package nablarch.fw.action;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * テストバッチリクエスト

--- a/src/test/java/nablarch/fw/batch/integration/BatchIntegrationInput.java
+++ b/src/test/java/nablarch/fw/batch/integration/BatchIntegrationInput.java
@@ -1,9 +1,9 @@
 package nablarch.fw.batch.integration;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * テストバッチインプット

--- a/src/test/java/nablarch/fw/batch/integration/BatchIntegrationOutput.java
+++ b/src/test/java/nablarch/fw/batch/integration/BatchIntegrationOutput.java
@@ -1,9 +1,9 @@
 package nablarch.fw.batch.integration;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * テストバッチアウトプット

--- a/src/test/java/nablarch/fw/batch/integration/TestBatchRequest3.java
+++ b/src/test/java/nablarch/fw/batch/integration/TestBatchRequest3.java
@@ -1,9 +1,9 @@
 package nablarch.fw.batch.integration;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * テストバッチリクエスト

--- a/src/test/java/nablarch/fw/handler/BasicDuplicateProcessCheckerTest.java
+++ b/src/test/java/nablarch/fw/handler/BasicDuplicateProcessCheckerTest.java
@@ -3,10 +3,10 @@ package nablarch.fw.handler;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import nablarch.core.db.transaction.SimpleDbTransactionManager;
 import nablarch.core.repository.SystemRepository;

--- a/src/test/java/nablarch/fw/handler/BasicProcessStopHandlerTest.java
+++ b/src/test/java/nablarch/fw/handler/BasicProcessStopHandlerTest.java
@@ -246,7 +246,7 @@ public class BasicProcessStopHandlerTest {
         try {
             for (int i = 0; i < 30; i++) {
                 result.add(String.valueOf(new ExecutionContext(context)
-                        .handleNext(
+                        .<String, String>handleNext(
                                 String.valueOf(i))));
             }
             fail("dose not run.");
@@ -307,7 +307,7 @@ public class BasicProcessStopHandlerTest {
         try {
             for (int i = 0; i < 30; i++) {
                 result.add(String.valueOf(new ExecutionContext(context)
-                        .handleNext(
+                        .<String, String>handleNext(
                                 String.valueOf(i))));
             }
             fail("dose not run.");

--- a/src/test/java/nablarch/fw/handler/HandlerBatchRequest.java
+++ b/src/test/java/nablarch/fw/handler/HandlerBatchRequest.java
@@ -1,9 +1,9 @@
 package nablarch.fw.handler;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * ハンドラテスト用バッチリクエスト

--- a/src/test/java/nablarch/fw/reader/BatchRequestTable.java
+++ b/src/test/java/nablarch/fw/reader/BatchRequestTable.java
@@ -1,9 +1,9 @@
 package nablarch.fw.reader;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * BATCH_REQUEST_TABLE

--- a/src/test/java/nablarch/fw/reader/MultiPrimaryKey.java
+++ b/src/test/java/nablarch/fw/reader/MultiPrimaryKey.java
@@ -1,9 +1,9 @@
 package nablarch.fw.reader;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * MULTI_PRIMARY_KEY

--- a/src/test/java/nablarch/fw/reader/ReaderBook.java
+++ b/src/test/java/nablarch/fw/reader/ReaderBook.java
@@ -1,9 +1,9 @@
 package nablarch.fw.reader;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * READER_BOOK

--- a/src/test/java/nablarch/fw/reader/ResumeBatchRequest.java
+++ b/src/test/java/nablarch/fw/reader/ResumeBatchRequest.java
@@ -1,9 +1,9 @@
 package nablarch.fw.reader;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * RESUME_BATCH_REQUEST


### PR DESCRIPTION
`handleNext` に型引数を追加している理由。

Java 8 以上だと型推論の挙動が変わったのか、曖昧な型の解決がうまくできずコンパイルエラーになるようになりました。
そのため、明示的に型引数を記述するようにしました。