### PR TITLE
データバインド向けデータリーダを作成・データリーダのスレッドセーフの責務を別クラスに切り出し

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,26 @@
     </dependency>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
+      <artifactId>nablarch-core-validation-ee</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.expressly</groupId>
+      <artifactId>expressly</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.nablarch.configuration</groupId>
+      <artifactId>nablarch-main-default-configuration</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-common-jdbc</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>com.nablarch.framework</groupId>
+      <artifactId>nablarch-common-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-common-jdbc</artifactId>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/nablarch/fw/action/DataBindBatchAction.java
+++ b/src/main/java/nablarch/fw/action/DataBindBatchAction.java
@@ -1,0 +1,43 @@
+package nablarch.fw.action;
+
+import nablarch.core.util.annotation.Published;
+import nablarch.fw.DataReaderFactory;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Handler;
+import nablarch.fw.Result;
+import nablarch.fw.reader.DataBindRecordReader;
+import nablarch.fw.reader.ResumeDataReader;
+import nablarch.fw.reader.ValidatableDataBindRecordReader;
+
+public abstract class DataBindBatchAction<D>
+        extends DataBindBatchActionBase<D>
+        implements Handler<D, Result>, DataReaderFactory<D> {
+    /**
+     * FileBatchActionオブジェクトを生成する。
+     */
+    @Published
+    public DataBindBatchAction() {
+        super();
+    }
+
+    // -------------------------------------------------- no need to override
+    /**
+     * データリーダを作成する。
+     * <p/>
+     * この実装では、入力ファイルを読み込む{@link DataBindRecordReader}を作成し、
+     * {@link ResumeDataReader}にラップして返却する。<br/>
+     * また、入力ファイルの事前検証処理が必要な場合は{@link #getValidatorAction()}をオーバーライドし、
+     * FileRecordReaderを{@link ValidatableDataBindRecordReader}でラップする。
+     */
+    public ResumeDataReader<D> createReader(ExecutionContext context) {
+        ValidatableDataBindRecordReader.DataBindFileValidatorAction<D> validator = getValidatorAction();
+        DataBindRecordReader<D> reader = (validator == null)
+                ? new DataBindRecordReader<>(getInputDataType())
+                : new ValidatableDataBindRecordReader<>(getInputDataType())
+                .setValidatorAction(validator);
+
+        reader.setDataFile(getDataFileDirName(), getDataFileName());
+
+        return new ResumeDataReader<D>().setSourceReader(reader);
+    }
+}

--- a/src/main/java/nablarch/fw/action/DataBindBatchActionBase.java
+++ b/src/main/java/nablarch/fw/action/DataBindBatchActionBase.java
@@ -1,0 +1,55 @@
+package nablarch.fw.action;
+
+import nablarch.core.util.annotation.Published;
+import nablarch.fw.DataReaderFactory;
+import nablarch.fw.Handler;
+import nablarch.fw.Result;
+import nablarch.fw.reader.ValidatableDataBindRecordReader;
+
+@Published
+public abstract class DataBindBatchActionBase<D>
+        extends BatchActionBase<D>
+        implements Handler<D, Result>, DataReaderFactory<D> {
+
+    /**
+     * 入力データの型を返す。
+     *
+     * @return 入力データの型
+     */
+    public abstract Class<D> getInputDataType();
+
+    /**
+     * 入力ファイルのファイル名を返す。
+     *
+     * @return 入力ファイルのファイル名
+     * @see nablarch.core.util.FilePathSetting
+     */
+    public abstract String getDataFileName();
+
+    /**
+     * 入力ファイル配置先の論理名を返す。
+     * <p/>
+     * デフォルト実装では"input"を返す。
+     * デフォルトの入力ファイル配置先以外から入力ファイルを取得する場合は、
+     * このメソッドをオーバーライドする。
+     *
+     * @return 入力ファイル配置先の論理名
+     */
+    public String getDataFileDirName() {
+        return "input";
+    }
+
+    /**
+     * 入力ファイルのバリデーションを実装したオブジェクトを返す。
+     * <p/>
+     * デフォルト実装ではバリデーションは行われない。
+     * 入力ファイルのバリデーションが必要な場合にオーバーライドすること。
+     *
+     * @return {@code null}または入力ファイルのバリデーションを実装したオブジェクト
+     */
+    public ValidatableDataBindRecordReader.DataBindFileValidatorAction<D> getValidatorAction() {
+        return null;
+    }
+
+
+}

--- a/src/main/java/nablarch/fw/reader/DataBindRecordReader.java
+++ b/src/main/java/nablarch/fw/reader/DataBindRecordReader.java
@@ -1,0 +1,219 @@
+package nablarch.fw.reader;
+
+import nablarch.common.databind.ObjectMapper;
+import nablarch.common.databind.ObjectMapperFactory;
+import nablarch.core.util.FilePathSetting;
+import nablarch.core.util.StringUtil;
+import nablarch.core.util.annotation.Published;
+import nablarch.fw.DataReader;
+import nablarch.fw.ExecutionContext;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+/**
+ * ファイルデータを１レコードづつ読み込み、
+ * 読み込んだフィールドの内容を{@code T}型のクラスにマッピングして返却するデータリーダ。
+ * <p/>
+ * 実際のレコード読み込み処理は、{@link ObjectMapper}に委譲する。
+ * <p/>
+ * このクラスを使用するにあたって設定が必須となるプロパティの実装例を下記に示す。
+ * 以下では、マッピング先のクラスを{@code SampleForm}としている。
+ * <pre>{@code
+ *     DataBindRecordReader<SampleForm> reader = new DataBindRecordReader<>(SampleForm.class)
+ *         //データファイルベースパス論理名とデータファイル名(拡張子無し)を設定する。
+ *         .setDataFile("input", "dataFile");
+ * }</pre>
+ *
+ * このクラスは読み込み対象のファイルが存在しない場合には例外を送出する。
+ * 読み込み対象のファイルが空(0バイト)の場合は、例外の送出は行わない。
+ *
+ * @param <T>
+ * @author Takayuki Uchida
+ */
+@Published(tag = "architect")
+public class DataBindRecordReader<T> implements DataReader<T> {
+
+    /** データファイル名 */
+    private String dataFileName = null;
+
+    /** データファイルのベースパス論理名 */
+    private String dataFileBasePathName = null;
+
+    /** 入力データの型 */
+    private final Class<T> inputDataType;
+
+    /** ファイル読み込み時にバッファを使用するかどうか。 */
+    private boolean useBuffer = true;
+
+    /** ファイル読み込みの際に使用するバッファのサイズ（デフォルトは8192B） */
+    private int bufferSize = 8192;
+
+    /** オブジェクトマッパーイテレータ。 */
+    private ObjectMapperIterator<T> iterator;
+
+    public DataBindRecordReader(Class<T> inputDataType) {
+        this.inputDataType = inputDataType;
+    }
+
+    @Override
+    public T read(ExecutionContext executionContext) {
+        if (iterator == null) {
+            iterator = createObjectMapperIterator();
+        }
+        return iterator.hasNext() ? iterator.next() : null;
+    }
+
+    @Override
+    public boolean hasNext(ExecutionContext executionContext) {
+        if (iterator == null) {
+            iterator = createObjectMapperIterator();
+        }
+        return iterator.hasNext();
+    }
+
+    @Override
+    public void close(ExecutionContext executionContext) {
+        if(iterator == null) {
+            return;
+        }
+        iterator.close();
+    }
+
+    /**
+     * データファイルのファイル名を設定する。
+     * <p/>
+     * "input"という論理名のベースパス配下に存在する当該ファイルがデータファイルとして使用される。
+     *
+     * @param fileName データファイル名
+     * @return このオブジェクト自体
+     */
+    @Published(tag = "architect")
+    public DataBindRecordReader<T> setDataFile(String fileName) {
+        return setDataFile("input", fileName);
+    }
+
+    /**
+     * データファイルのベースパス論理名およびファイル名を設定する。
+     * <p/>
+     * 設定したベースパス配下に存在する当該のファイルがデータファイルとして使用される。
+     *
+     * @param basePathName ベースパス論理名
+     * @param fileName データファイル名
+     * @return このオブジェクト自体
+     */
+    @Published(tag = "architect")
+    public DataBindRecordReader<T> setDataFile(String basePathName, String fileName) {
+        this.dataFileBasePathName = basePathName;
+        this.dataFileName = fileName;
+        return this;
+    }
+
+    @Published(tag = "architect")
+    public DataBindRecordReader<T> setUseBuffer(boolean useBuffer) {
+        this.useBuffer = useBuffer;
+        return this;
+    }
+
+    @Published(tag = "architect")
+    public DataBindRecordReader<T> setBufferSize(int bufferSize) {
+        if(bufferSize <= 0) {
+            throw new IllegalArgumentException("buffer size was invalid. buffer size must be greater than 0.");
+        }
+        this.bufferSize = bufferSize;
+        return this;
+    }
+
+    /**
+     * {@link ObjectMapper}を生成する。
+     *
+     * @return {@link ObjectMapper}オブジェクト
+     * @throws IllegalStateException 必須であるプロパティが設定されていない場合、読み込み対象のファイルが存在しない場合
+     */
+    private ObjectMapperIterator<T> createObjectMapperIterator() {
+        File dataFile = getDataFile();
+        // ファイルの読み出しに利用するイテレータを生成
+        try {
+            InputStream is = new FileInputStream(dataFile);
+            if (useBuffer) {
+                return new ObjectMapperIterator<T>(ObjectMapperFactory.create(inputDataType, new BufferedInputStream(is, bufferSize)));
+            }
+            return new ObjectMapperIterator<T>(ObjectMapperFactory.create(inputDataType, is));
+        } catch (FileNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private File getDataFile() {
+        if (StringUtil.isNullOrEmpty(dataFileName)) {
+            throw new IllegalStateException("data file name was blank. data file name must not be blank.");
+        }
+        if (StringUtil.isNullOrEmpty(dataFileBasePathName)) {
+            throw new IllegalStateException("data file base path name was blank. data file base path name must not be blank.");
+        }
+
+        // データファイルオブジェクトの生成
+        FilePathSetting filePathSetting = FilePathSetting.getInstance();
+        return filePathSetting.getFileWithoutCreate(dataFileBasePathName, dataFileName);
+    }
+
+    private static class ObjectMapperIterator<E> implements Iterator<E> {
+
+        /**　オブジェクトマッパー */
+        private final ObjectMapper<E> mapper;
+
+        /** データ1行分のオブジェクト */
+        private E form;
+
+        /**
+         * {@link ObjectMapper}を引数にObjectMapperIteratorを生成する。
+         *
+         * @param mapper イテレートするマッパ
+         */
+        public ObjectMapperIterator(ObjectMapper<E> mapper) {
+            this.mapper = mapper;
+
+            // 初回分のデータを読み込む
+            form = mapper.read();
+        }
+
+        /**
+         * 次の行があるかどうかを返す。
+         *
+         * @return {@code true} 次の行がある場合、 {@code false} 次の行がない場合
+         */
+        @Override
+        public boolean hasNext() {
+            return (form != null);
+        }
+
+        /**
+         * 1行分のデータを返す。
+         *
+         * @return 1行分のデータ
+         */
+        @Override
+        public E next() {
+
+            final E current = form;
+            form = mapper.read();
+            return current;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * マッパをクローズする。
+         */
+        public void close() {
+            mapper.close();
+        }
+    }
+}

--- a/src/main/java/nablarch/fw/reader/DatabaseRecordReader.java
+++ b/src/main/java/nablarch/fw/reader/DatabaseRecordReader.java
@@ -50,7 +50,7 @@ public class DatabaseRecordReader implements DataReader<SqlRow> {
      * @param ctx 実行コンテキスト
      * @return レコードデータをキャッシュするオブジェクト
      */
-    public synchronized SqlRow read(ExecutionContext ctx) {
+    public SqlRow read(ExecutionContext ctx) {
         if (records == null) {
             readRecords();
         }
@@ -66,7 +66,7 @@ public class DatabaseRecordReader implements DataReader<SqlRow> {
      * @param ctx 実行コンテキスト
      * @return 次に読み込むレコードが存在する場合 {@code true}
      */
-    public synchronized boolean hasNext(ExecutionContext ctx) {
+    public boolean hasNext(ExecutionContext ctx) {
         if (records == null) {
             readRecords();
         }
@@ -81,7 +81,7 @@ public class DatabaseRecordReader implements DataReader<SqlRow> {
      *
      *  @param ctx 実行コンテキスト
      */
-    public synchronized void close(ExecutionContext ctx) {
+    public void close(ExecutionContext ctx) {
         if (statement != null) {
             statement.close();
         }
@@ -94,7 +94,7 @@ public class DatabaseRecordReader implements DataReader<SqlRow> {
      *
      * @param ctx 実行コンテキスト
      */
-    public synchronized void reopen(ExecutionContext ctx) {
+    public void reopen(ExecutionContext ctx) {
         readRecords();
     }
 
@@ -130,7 +130,7 @@ public class DatabaseRecordReader implements DataReader<SqlRow> {
      * @return このオブジェクト自体
      */
     @Published
-    public synchronized DatabaseRecordReader setStatement(SqlPStatement statement) {
+    public DatabaseRecordReader setStatement(SqlPStatement statement) {
         this.statement = statement;
         return this;
     }

--- a/src/main/java/nablarch/fw/reader/DatabaseTableQueueReader.java
+++ b/src/main/java/nablarch/fw/reader/DatabaseTableQueueReader.java
@@ -90,7 +90,7 @@ public class DatabaseTableQueueReader implements DataReader<SqlRow> {
      * @return レコード
      */
     @Override
-    public synchronized SqlRow read(ExecutionContext ctx) {
+    public SqlRow read(ExecutionContext ctx) {
         if (!originalReader.hasNext(ctx)) {
             // データが存在しない場合は、待機時間分待機後にリソース(カーソル)を開き直す。
             waitThread();
@@ -137,7 +137,7 @@ public class DatabaseTableQueueReader implements DataReader<SqlRow> {
      * @return 読み込むデータが存在する場合 {@code true}
      */
     @Override
-    public synchronized boolean hasNext(ExecutionContext ctx) {
+    public boolean hasNext(ExecutionContext ctx) {
         return !closed;
     }
 
@@ -147,7 +147,7 @@ public class DatabaseTableQueueReader implements DataReader<SqlRow> {
      * @param ctx 実行コンテキスト
      */
     @Override
-    public synchronized void close(ExecutionContext ctx) {
+    public void close(ExecutionContext ctx) {
         closed = true;
         originalReader.close(ctx);
     }

--- a/src/main/java/nablarch/fw/reader/FileDataReader.java
+++ b/src/main/java/nablarch/fw/reader/FileDataReader.java
@@ -66,7 +66,7 @@ public class FileDataReader implements DataReader<DataRecord> {
      * @param ctx 実行コンテキスト
      * @return 1レコード分のデータレコード（読み込むデータがなかった場合は{@code null}）
      */
-    public synchronized DataRecord read(ExecutionContext ctx) {
+    public DataRecord read(ExecutionContext ctx) {
         if (fileReader == null) {
             fileReader = createFileRecordReader();
         }
@@ -84,7 +84,7 @@ public class FileDataReader implements DataReader<DataRecord> {
      * @param ctx 実行コンテキスト
      * @return 読み込むデータが存在する場合は {@code true}
      */
-    public synchronized boolean hasNext(ExecutionContext ctx) {
+    public boolean hasNext(ExecutionContext ctx) {
         if (fileReader == null) {
             fileReader = createFileRecordReader();
         }
@@ -98,7 +98,7 @@ public class FileDataReader implements DataReader<DataRecord> {
      * <p/>
      * このリーダが既に閉じられている場合は何もしない。
      */ 
-    public synchronized void close(ExecutionContext ctx) {
+    public void close(ExecutionContext ctx) {
         if (fileReader == null) {
             return;
         }
@@ -211,7 +211,7 @@ public class FileDataReader implements DataReader<DataRecord> {
      * {@code FileRecordReader}オブジェクトを取得する。
      * @return FileRecordReaderオブジェクト（FileRecordReaderオブジェクトが生成されていない場合は{@code null}）
      */
-    protected synchronized FileRecordReader getFileReader() {
+    protected FileRecordReader getFileReader() {
         return fileReader;
     }
 
@@ -219,7 +219,8 @@ public class FileDataReader implements DataReader<DataRecord> {
      * {@code FileRecordReader}オブジェクトを設定する。
      * @param fileReader {@code FileRecordReader}オブジェクト
      */
-    protected synchronized void setFileReader(FileRecordReader fileReader) {
+
+    protected void setFileReader(FileRecordReader fileReader) {
         this.fileReader = fileReader;
     }
     

--- a/src/main/java/nablarch/fw/reader/ResumeDataReader.java
+++ b/src/main/java/nablarch/fw/reader/ResumeDataReader.java
@@ -49,7 +49,7 @@ public class ResumeDataReader<TData> implements DataReader<TData> {
      * @return 入力データオブジェクト
      */
     @Override
-    public synchronized TData read(ExecutionContext ctx) {
+    public TData read(ExecutionContext ctx) {
         if (!sourceReader.hasNext(ctx)) {
             return null;
         }
@@ -72,7 +72,7 @@ public class ResumeDataReader<TData> implements DataReader<TData> {
      * @return 次に読み込むデータが存在する場合は{@code true}
      */
     @Override
-    public synchronized boolean hasNext(ExecutionContext ctx) {
+    public boolean hasNext(ExecutionContext ctx) {
         return sourceReader.hasNext(ctx);
     }
 
@@ -82,7 +82,7 @@ public class ResumeDataReader<TData> implements DataReader<TData> {
      * @param ctx 実行コンテキスト
      */
     @Override
-    public synchronized void close(ExecutionContext ctx) {
+    public void close(ExecutionContext ctx) {
         sourceReader.close(ctx);
     }
 
@@ -157,7 +157,7 @@ public class ResumeDataReader<TData> implements DataReader<TData> {
      * @param sourceReader レジューム機能を追加するデータリーダ
      * @return このオブジェクト自体
      */
-    public synchronized ResumeDataReader<TData> setSourceReader(DataReader<TData> sourceReader) {
+    public ResumeDataReader<TData> setSourceReader(DataReader<TData> sourceReader) {
         this.sourceReader = sourceReader;
         return this;
     }

--- a/src/main/java/nablarch/fw/reader/ValidatableDataBindRecordReader.java
+++ b/src/main/java/nablarch/fw/reader/ValidatableDataBindRecordReader.java
@@ -1,0 +1,258 @@
+package nablarch.fw.reader;
+
+import nablarch.core.log.Logger;
+import nablarch.core.log.LoggerManager;
+import nablarch.core.util.annotation.Published;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Handler;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * ファイル内容のバリデーション機能を追加したデータリーダ。
+ * <p>
+ * ファイル全件の読み込みを行い、このリーダが提供する{@link DataBindFileValidatorAction}に実装されたバリデーションロジックを
+ * {@link #setValidatorAction(DataBindFileValidatorAction)}から設定することができる。
+ * バリデーションが正常終了した場合は、入力ファイルを開きなおして本処理を行う。
+ * また、{@link #setUseCache(boolean)}に{@code true}を設定することで、バリデーション時に読み込んだデータを
+ * メモリ上にキャッシュし、都度2回の読み込みを1回に削減することができる。
+ * ただし、データ量によってはメモリリソースを大幅に消費する点に注意すること。
+ * <p>
+ * バリデーションが失敗した場合、このデータリーダは例外を送出してクローズされる。
+ *
+ *
+ * @author Takayuki Uchida
+ */
+public class ValidatableDataBindRecordReader<T> extends DataBindRecordReader<T>{
+
+    /** ロガー */
+    private static final Logger LOGGER = LoggerManager.get(ValidatableDataBindRecordReader.class);
+
+    /**
+     * コンストラクタ。
+     *
+     * @param inputDataType 入力データの型
+     */
+    @Published(tag = "architect")
+    public ValidatableDataBindRecordReader(Class<T> inputDataType) {
+        super(inputDataType);
+    }
+
+    /**
+     * バリデーションを行うオブジェクトが実装するインタフェース。
+     */
+    @Published
+    public interface DataBindFileValidatorAction<T> extends Handler<T, Object> {
+        /**
+         * ファイル全件の読み込みが正常終了し、
+         * ファイル終端に達するとコールバックされる
+         * @param ctx 実行コンテキスト
+         */
+        void onFileEnd(ExecutionContext ctx);
+    }
+
+    /** バリデーションを実装したハンドラ */
+    private DataBindFileValidatorAction<T> validatorAction = null;
+
+    /** バリデーション時に読み込んだデータを本処理で使用するかどうか。 */
+    private boolean useCache = false;
+
+    /** バリデーションで読み込んだデータを格納するキャッシュ */
+    private List<T> recordCache = null;
+
+    /** バリデーション済みフラグ */
+    private boolean validated = false;
+
+    /**
+     * データファイルを1レコードづつ読み込む。
+     * <p/>
+     * ファイルがバリデーション済みでない場合、バリデーションを行う。<br/>
+     * 次に読み込むレコードが存在しない場合、{@code null}を返す。
+     * <p/>
+     * データをキャッシュしている場合、キャッシュからデータを読み込み返却する。<br/>
+     * キャッシュしていない場合、データファイルからデータを読み込み返却する。
+     *
+     * @param ctx 実行コンテキスト
+     * @return １レコード分のデータレコード
+     */
+    @Override
+    public T read(ExecutionContext ctx) {
+        if (!validated) {
+            validate(ctx);
+        }
+        if (useCache) {
+            return (recordCache == null || recordCache.isEmpty())
+                    ? null
+                    : recordCache.remove(0);
+        }
+        return super.read(ctx);
+    }
+
+    /**
+     * 次に読み込むデータが存在するかどうかを返却する。
+     * <p/>
+     * データをキャッシュしている場合、キャッシュから結果を返却する。<br/>
+     * キャッシュしていない場合、データファイルから結果を返却する。
+     *
+     * @param ctx 実行コンテキスト
+     * @return 次に読み込むデータが存在する場合は {@code true}
+     */
+    @Override
+    public boolean hasNext(ExecutionContext ctx) {
+        if (validated && useCache) {
+            return recordCache != null && !recordCache.isEmpty();
+        }
+        return super.hasNext(ctx);
+    }
+
+    /**
+     * このリーダの利用を停止し、内部的に保持している各種リソースを解放する。
+     * <p/>
+     * キャッシュを有効にしていた場合、キャッシュを削除する。
+     *
+     * @param ctx 実行コンテキスト
+     */
+    @Override
+    public void close(ExecutionContext ctx) {
+        if (useCache) {
+            if(recordCache != null) {
+                recordCache.clear();
+            }
+            recordCache = null;
+        }
+        super.close(ctx);
+    }
+
+
+    /**
+     * バリデーションを行う。
+     * <p>
+     * {@link ValidatableDataBindRecordReader#useCache}が{@code true}である場合、読み込んだデータをキャッシュする。
+     *
+     * @param ctx 実行コンテキスト
+     * @throws IllegalStateException バリデーション処理を実装したオブジェクトが{@code null}の場合
+     * @throws RuntimeException 実行時例外が発生した場合
+     * @throws Error エラーが発生した場合
+     */
+    protected void validate(ExecutionContext ctx) {
+        if (validatorAction == null) {
+            throw new IllegalStateException(
+                    "FileValidatorAction was not set. an Object that implements the validation logic must be set."
+            );
+        }
+        try {
+            Handler<T, Object> validateHandler = validatorAction;
+
+            if (useCache) {
+                recordCache = new LinkedList<>();
+            }
+            while (super.hasNext(ctx)) {
+                T record = super.read(ctx);
+                validateHandler.handle(record, ctx);
+                if (useCache) {
+                    recordCache.add(record);
+                }
+            }
+            validatorAction.onFileEnd(ctx);
+            super.close(ctx);
+            if (!useCache) {
+                initialize();
+            }
+        } catch (RuntimeException | Error e) {
+            try {
+                close(ctx);
+            } catch (Throwable t) {
+                LOGGER.logWarn("failed to release file resource.", t);
+            }
+            throw e;
+        } finally {
+            validated = true;
+        }
+    }
+
+    /**
+     * データリーダを初期化し、再度使用できるようにする。
+     */
+    protected void initialize() {
+        super.setObjectMapperIterator(null);
+    }
+
+    /**
+     * バリデーション時に読み込んだデータをキャッシュし、本処理で使用するかどうかを設定する。
+     *
+     * @param useCache キャッシュを有効化する場合は{@code true}
+     * @return このオブジェクト自体
+     */
+    @Published(tag = "architect")
+    public ValidatableDataBindRecordReader<T> setUseCache(boolean useCache) {
+        this.useCache = useCache;
+        return this;
+    }
+
+    /**
+     * バリデーション処理を実装したアクションクラスを設定する。
+     *
+     * @param validatorAction バリデーションを実装したアクションクラス
+     * @return このオブジェクト自体
+     * @throws IllegalArgumentException バリデーションを実装したアクションクラスが{@code null}の場合
+     */
+    @Published(tag = "architect")
+    public ValidatableDataBindRecordReader<T> setValidatorAction(DataBindFileValidatorAction<T> validatorAction) {
+        if (validatorAction == null) {
+            throw new IllegalArgumentException("validator action was null. validator action must not be null.");
+        }
+        this.validatorAction = validatorAction;
+        return this;
+    }
+
+    /**
+     * データファイルのファイル名を設定する。
+     * <p/>
+     * "input"という論理名のベースパス配下に存在する当該ファイルがデータファイルとして使用される。
+     *
+     * @param fileName データファイル名
+     * @return このオブジェクト自体
+     */
+    @Published(tag = "architect")
+    public ValidatableDataBindRecordReader<T> setDataFile(String fileName) {
+        return (ValidatableDataBindRecordReader<T>) super.setDataFile(fileName);
+    }
+
+    /**
+     * データファイルのベースパス論理名およびファイル名を設定する。
+     * <p/>
+     * 設定したベースパス配下に存在する当該のファイルがデータファイルとして使用される。
+     *
+     * @param basePathName ベースパス論理名
+     * @param fileName データファイル名
+     * @return このオブジェクト自体
+     */
+    @Published(tag = "architect")
+    public ValidatableDataBindRecordReader<T> setDataFile(String basePathName, String fileName) {
+        return (ValidatableDataBindRecordReader<T>) super.setDataFile(basePathName, fileName);
+    }
+
+    /**
+     * ファイル読み込み時にバッファーを使用するか否かを設定する。
+     *
+     * @param useBuffer バッファーを使用する場合は {@code true}
+     * @return このオブジェクト自体
+     */
+    @Published(tag = "architect")
+    public ValidatableDataBindRecordReader<T> setUseBuffer(boolean useBuffer) {
+        return (ValidatableDataBindRecordReader<T>) super.setUseBuffer(useBuffer);
+    }
+
+    /**
+     * ファイル読み込み時のバッファーサイズを設定する。
+     *
+     * @param bufferSize バッファーサイズ
+     * @return このオブジェクト自体
+     */
+    @Published(tag = "architect")
+    public ValidatableDataBindRecordReader<T> setBufferSize(int bufferSize) {
+        return (ValidatableDataBindRecordReader<T>) super.setBufferSize(bufferSize);
+    }
+
+}

--- a/src/main/java/nablarch/fw/reader/ValidatableFileDataReader.java
+++ b/src/main/java/nablarch/fw/reader/ValidatableFileDataReader.java
@@ -87,7 +87,7 @@ public class ValidatableFileDataReader extends FileDataReader {
      * @return １レコード分のデータレコード
      */
     @Override
-    public synchronized DataRecord read(ExecutionContext ctx) {
+    public DataRecord read(ExecutionContext ctx) {
         if (!validated) {
             validate(ctx);
         }
@@ -109,12 +109,9 @@ public class ValidatableFileDataReader extends FileDataReader {
      * @return 次に読み込むデータが存在する場合は {@code true}
      */
     @Override
-    public synchronized boolean hasNext(ExecutionContext ctx) {
+    public boolean hasNext(ExecutionContext ctx) {
         if (validated && useCache) {
-            synchronized (this) {
-                return (recordCache == null) ? false
-                                             : !recordCache.isEmpty();
-            }
+            return recordCache != null && !recordCache.isEmpty();
         }
         return super.hasNext(ctx);
     }
@@ -127,7 +124,7 @@ public class ValidatableFileDataReader extends FileDataReader {
      * @param ctx 実行コンテキスト
      */
     @Override
-    public synchronized void close(ExecutionContext ctx) {
+    public void close(ExecutionContext ctx) {
         if (useCache) {
             recordCache.clear();
             recordCache = null;
@@ -220,7 +217,7 @@ public class ValidatableFileDataReader extends FileDataReader {
      * @return このオブジェクト自体
      */
     @Published(tag = "architect")
-    public synchronized ValidatableFileDataReader setUseCache(boolean useCache) {
+    public ValidatableFileDataReader setUseCache(boolean useCache) {
         this.useCache = useCache;
         return this;
     }

--- a/src/main/java/nablarch/fw/reader/iterator/ObjectMapperIterator.java
+++ b/src/main/java/nablarch/fw/reader/iterator/ObjectMapperIterator.java
@@ -1,0 +1,82 @@
+package nablarch.fw.reader.iterator;
+
+import nablarch.common.databind.ObjectMapper;
+
+import java.util.Iterator;
+
+/**
+ * {@link ObjectMapper}で読み込んだファイルの内容を一行ずつ返す{@link Iterator}実装クラス。
+ *
+ * @param <T> {@link ObjectMapper} でバインドするクラスの型
+ */
+public class ObjectMapperIterator <T> implements Iterator<T> {
+
+    /**　オブジェクトマッパー */
+    private final ObjectMapper<T> mapper;
+
+    /** データ1行分のオブジェクト */
+    private T form;
+
+    /**
+     * オブジェクトマッパーがクローズ済みかどうか。
+     */
+    private boolean closed = false;
+
+    /**
+     * {@link ObjectMapper}を引数にObjectMapperIteratorを生成する。
+     *
+     * @param mapper イテレートするマッパ
+     */
+    public ObjectMapperIterator(ObjectMapper<T> mapper) {
+        this.mapper = mapper;
+
+        // 初回分のデータを読み込む
+        form = mapper.read();
+    }
+
+    /**
+     * 次の行があるかどうかを返す。
+     *
+     * @return {@code true} 次の行がある場合、 {@code false} 次の行がない場合
+     */
+    @Override
+    public boolean hasNext() {
+        if(closed) {
+            return false;
+        }
+        return (form != null);
+    }
+
+    /**
+     * 1行分のデータを返す。
+     *
+     * @return 1行分のデータ
+     */
+    @Override
+    public T next() {
+        if(closed) {
+            return null;
+        }
+        final T current = form;
+        form = mapper.read();
+        return current;
+    }
+
+    /**
+     * このメソッドはサポートされない。
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * マッパーをクローズする。
+     */
+    public void close() {
+        if(!closed) {
+            mapper.close();
+        }
+        closed = true;
+    }
+}

--- a/src/test/java/nablarch/fw/action/BatchActionBaseTest.java
+++ b/src/test/java/nablarch/fw/action/BatchActionBaseTest.java
@@ -9,13 +9,11 @@ import java.util.Map;
 
 import nablarch.core.ThreadContext;
 import nablarch.core.dataformat.DataRecord;
-import nablarch.core.repository.SystemRepository;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.log.app.OnMemoryLogWriter;
 import nablarch.test.support.message.MockStringResourceHolder;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/src/test/java/nablarch/fw/action/DataBindBatchActionTest.java
+++ b/src/test/java/nablarch/fw/action/DataBindBatchActionTest.java
@@ -10,7 +10,11 @@ import nablarch.test.support.db.helper.DatabaseTestRunner;
 import nablarch.test.support.db.helper.TargetDb;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
 import nablarch.test.support.handler.CatchingHandler;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;

--- a/src/test/java/nablarch/fw/action/DataBindBatchActionTest.java
+++ b/src/test/java/nablarch/fw/action/DataBindBatchActionTest.java
@@ -1,0 +1,342 @@
+package nablarch.fw.action;
+
+import nablarch.core.message.ApplicationException;
+import nablarch.core.repository.SystemRepository;
+import nablarch.fw.Result;
+import nablarch.fw.TestSupport;
+import nablarch.fw.launcher.CommandLine;
+import nablarch.fw.launcher.Main;
+import nablarch.test.support.db.helper.DatabaseTestRunner;
+import nablarch.test.support.db.helper.TargetDb;
+import nablarch.test.support.db.helper.VariousDbTestHelper;
+import nablarch.test.support.handler.CatchingHandler;
+import org.junit.*;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("NonAsciiCharacters")
+@RunWith(DatabaseTestRunner.class)
+public class DataBindBatchActionTest {
+
+
+    private static final File tempDir = new File(System.getProperty("java.io.tmpdir"));
+
+    private final File dataFile = new File(tempDir, "test.dat");
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        VariousDbTestHelper.createTable(TestBatchRequest.class);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        VariousDbTestHelper.dropTable(TestBatchRequest.class);
+    }
+
+    @Before
+    public void setUp() {
+        CatchingHandler.clear();
+        VariousDbTestHelper.setUpTable(
+                new TestBatchRequest("req00001", 0)
+        );
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @After
+    public void tearDown() {
+        SystemRepository.clear();
+        CatchingHandler.clear();
+        if (dataFile.exists()) {
+            dataFile.delete();
+        }
+    }
+
+
+    @Test
+    public void バッチの実行が正常終了すること() throws Exception {
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        CommandLine commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTest.xml"
+                , "-requestPath", "TinyDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        int exitCode = Main.execute(commandline);
+
+        assertEquals(0, exitCode);
+
+        List<Result> results = CatchingHandler.getResults();
+        assertEquals(3, results.size());
+        assertEquals("山田太郎", results.get(0).getMessage());
+        assertEquals("鈴木次郎", results.get(1).getMessage());
+        assertEquals("佐藤花子", results.get(2).getMessage());
+
+        List<String> execIds = CatchingHandler.getExecutionIds();
+        assertEquals(3, execIds.size());
+        Set<String> ids = new HashSet<>();
+        for (String execId : execIds) {
+            assertTrue(execId.matches("\\d{21}"));
+            ids.add(execId);
+        }
+        assertEquals(3, ids.size());
+    }
+
+    @Test
+    public void ディスパッチ先が存在しない場合は異常終了すること() throws Exception {
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        CommandLine commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTest.xml"
+                , "-requestPath", "NoneDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        int exitCode = Main.execute(commandline);
+        assertEquals(13, exitCode);
+    }
+
+    @Test
+    public void handle内のバリデーションに失敗した場合は異常終了すること() throws Exception {
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "300,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        CommandLine commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTest.xml"
+                , "-requestPath", "TinyDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        int exitCode = Main.execute(commandline);
+        assertEquals(20, exitCode);
+
+        List<Result> results = CatchingHandler.getResults();
+        assertEquals(2, results.size());
+        assertEquals("山田太郎", results.get(0).getMessage());
+
+        Exception exception = (Exception) results.get(1);
+        assertTrue(exception instanceof ApplicationException);
+        assertEquals("年齢が不正です。\n", exception.getMessage()); // ApplicationException.getMessage()でLFを付与している
+    }
+
+    @Test
+    public void 事前の全件バリデーションに失敗した場合は異常終了すること() throws Exception {
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "300,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        CommandLine commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTest.xml"
+                , "-requestPath", "TinyDataBindBatchActionWithPreCheck/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        int exitCode = Main.execute(commandline);
+        assertEquals(20, exitCode);
+
+        List<Result> results = CatchingHandler.getResults();
+        assertEquals(1, results.size());
+        Exception exception = (Exception) results.get(0);
+        assertTrue(exception instanceof ApplicationException);
+        assertEquals("年齢が不正です。\n", exception.getMessage()); // ApplicationException.getMessage()でLFを付与している
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    @TargetDb
+    public void バリデーションに失敗してもレジュームポイントから処理を続行できること() throws Exception {
+
+        // エラーを発生させるファイルを作成する。
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "400,佐藤花子",
+                "50,高橋葉子"
+        );
+
+        // 1回目の実行
+        CommandLine commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTest.xml"
+                , "-requestPath", "TinyDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        int exitCode = Main.execute(commandline);
+        assertEquals(20, exitCode);
+
+        // 1回目の実行では、3番目のデータでエラーが発生する。
+        List<Result> results = CatchingHandler.getResults();
+        assertEquals(3, results.size());
+        assertEquals("山田太郎", results.get(0).getMessage());
+        assertEquals("鈴木次郎", results.get(1).getMessage());
+        Exception exception = (Exception) results.get(2);
+        assertTrue(exception instanceof RuntimeException);
+        assertEquals("年齢が不正です。\n", exception.getMessage());
+
+
+        CatchingHandler.clear();
+
+        // エラー箇所を修正したファイルを作成する。
+        if(dataFile.exists()) {
+            dataFile.delete();
+        }
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子",
+                "50,高橋葉子"
+        );
+
+        // 2回目の実行
+        commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTest.xml"
+                , "-requestPath", "TinyDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        exitCode = Main.execute(commandline);
+        assertEquals(0, exitCode);
+
+        // 2回目の実行では、3番目のデータから処理が実行される。
+        results = CatchingHandler.getResults();
+        assertEquals(2, results.size());
+        assertEquals("佐藤花子", results.get(0).getMessage());
+        assertEquals("高橋葉子", results.get(1).getMessage());
+
+
+
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    @TargetDb
+    public void コミット間隔を3に設定した場合_バリデーションに失敗してもレジュームポイントから処理を続行できること() throws Exception {
+
+        // エラーを発生させるファイルを作成する。2番目と4番目のデータが不正
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "300,鈴木次郎",
+                "40,佐藤花子",
+                "500,高橋葉子",
+                "60,藤原芳雄"
+        );
+
+
+        // 1回目の実行
+        CommandLine commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTestLoop.xml"
+                , "-requestPath", "TinyDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        int exitCode = Main.execute(commandline);
+        assertEquals(20, exitCode);
+
+        // 1回目の実行では、2番目のデータでエラーが発生し、処理がロールバックする。
+        List<Result> results = CatchingHandler.getResults();
+        assertEquals(2, results.size());
+        assertEquals("山田太郎", results.get(0).getMessage());
+        Exception exception = (Exception) results.get(1);
+        assertTrue(exception instanceof RuntimeException);
+        assertEquals("年齢が不正です。\n", exception.getMessage());
+
+        CatchingHandler.clear();
+
+        // エラー箇所を修正したファイルを作成する。4番目のデータにはまだ不正が残っている。
+        if(dataFile.exists()) {
+            dataFile.delete();
+        }
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子",
+                "500,高橋葉子",
+                "60,藤原芳雄"
+        );
+
+        // 2回目の実行
+        commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTestLoop.xml"
+                , "-requestPath", "TinyDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        exitCode = Main.execute(commandline);
+        assertEquals(20, exitCode);
+
+        // 1回目の実行がロールバックされているので、最初から処理され、4番目のデータでエラーが発生する。
+        results = CatchingHandler.getResults();
+        assertEquals(4, results.size());
+        assertEquals("山田太郎", results.get(0).getMessage());
+        assertEquals("鈴木次郎", results.get(1).getMessage());
+        assertEquals("佐藤花子", results.get(2).getMessage());
+        exception = (Exception) results.get(3);
+        assertTrue(exception instanceof RuntimeException);
+        assertEquals("年齢が不正です。\n", exception.getMessage());
+
+        CatchingHandler.clear();
+
+        // エラー箇所を修正したファイルを作成する。
+        if(dataFile.exists()) {
+            dataFile.delete();
+        }
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子",
+                "50,高橋葉子",
+                "60,藤原芳雄"
+        );
+
+        // 3回目の実行
+        commandline = new CommandLine(
+                "-diConfig", "nablarch/fw/action/DataBindBatchActionTestLoop.xml"
+                , "-requestPath", "TinyDataBindBatchAction/req00001"
+                , "-userId", "NabuTaro"
+        );
+
+        exitCode = Main.execute(commandline);
+        assertEquals(0, exitCode);
+
+        // 3回目の実行では、4番目のデータから処理が実行される。
+        results = CatchingHandler.getResults();
+        assertEquals(2, results.size());
+        assertEquals("高橋葉子", results.get(0).getMessage());
+        assertEquals("藤原芳雄", results.get(1).getMessage());
+
+    }
+}

--- a/src/test/java/nablarch/fw/action/TinyDataBindBatchAction.java
+++ b/src/test/java/nablarch/fw/action/TinyDataBindBatchAction.java
@@ -1,0 +1,24 @@
+package nablarch.fw.action;
+
+import nablarch.core.validation.ee.ValidatorUtil;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Result;
+import nablarch.fw.reader.DataBindTestForm;
+
+public class TinyDataBindBatchAction extends DataBindBatchAction<DataBindTestForm>{
+
+    @Override
+    public Class<DataBindTestForm> getInputDataType() {
+        return DataBindTestForm.class;
+    }
+
+    @Override
+    public String getDataFileName() {
+        return "test";
+    }
+
+    public Result handle(DataBindTestForm form, ExecutionContext ctx) {
+        ValidatorUtil.validate(form);
+        return new Result.Success(form.getName());
+    }
+}

--- a/src/test/java/nablarch/fw/action/TinyDataBindBatchActionWithPreCheck.java
+++ b/src/test/java/nablarch/fw/action/TinyDataBindBatchActionWithPreCheck.java
@@ -1,0 +1,43 @@
+package nablarch.fw.action;
+
+import nablarch.core.validation.ee.ValidatorUtil;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Result;
+import nablarch.fw.reader.DataBindTestForm;
+import nablarch.fw.reader.ValidatableDataBindRecordReader.DataBindFileValidatorAction;
+
+
+public class TinyDataBindBatchActionWithPreCheck extends DataBindBatchAction<DataBindTestForm>{
+
+    @Override
+    public Class<DataBindTestForm> getInputDataType() {
+        return DataBindTestForm.class;
+    }
+
+    @Override
+    public String getDataFileName() {
+        return "test";
+    }
+
+    @Override
+    public DataBindFileValidatorAction<DataBindTestForm> getValidatorAction() {
+
+        return new DataBindFileValidatorAction<>() {
+            @Override
+            public void onFileEnd(ExecutionContext ctx) {
+                // nop
+            }
+
+            @Override
+            public Object handle(DataBindTestForm dataBindTestForm, ExecutionContext context) {
+                ValidatorUtil.validate(dataBindTestForm);
+                return new Result.Success();
+            }
+        };
+    }
+
+    public Result handle(DataBindTestForm form, ExecutionContext ctx) {
+        ValidatorUtil.validate(form);
+        return new Result.Success(form.getName());
+    }
+}

--- a/src/test/java/nablarch/fw/reader/DataBindRecordReaderTest.java
+++ b/src/test/java/nablarch/fw/reader/DataBindRecordReaderTest.java
@@ -4,14 +4,13 @@ import nablarch.fw.ExecutionContext;
 import nablarch.fw.TestSupport;
 import nablarch.test.support.SystemRepositoryResource;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -37,10 +36,6 @@ public class DataBindRecordReaderTest {
 
     private DataBindRecordReader<DataBindTestForm> sut = null;
 
-    @Before
-    public void setUp() throws Exception {
-    }
-
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @After
     public void tearDown() throws Exception {
@@ -55,10 +50,10 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void ファイルを読み込めること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
-                        .setDataFile("record");
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record");
 
-        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
                 "年齢,氏名",
                 "20,山田太郎",
                 "30,鈴木次郎",
@@ -83,10 +78,10 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void hasNextなしでreadを呼び出した場合もファイルを読み込めること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
-                        .setDataFile("record");
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record");
 
-        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
                 "年齢,氏名",
                 "20,山田太郎",
                 "30,鈴木次郎",
@@ -107,14 +102,34 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void 初期化前にcloseを呼び出した場合は例外が送出されないこと() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
-                        .setDataFile("record");
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record");
         sut.close(new ExecutionContext());
     }
 
     @Test
+    public void close後にデータリーダにアクセスした場合は例外が発生しないこと() throws Exception {
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record");
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        sut.read(ctx);
+        sut.close(ctx);
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
     public void データファイルが存在しない場合は例外が送出されること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile("record");
 
         expectedException.expect(IllegalStateException.class);
@@ -129,7 +144,7 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void データファイルを指定しない場合は例外が送出されること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class);
+        sut = new DataBindRecordReader<>(DataBindTestForm.class);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("data file name was blank. data file name must not be blank.");
@@ -139,7 +154,7 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void データファイルにnullを指定した場合は例外が送出されること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile(null);
 
         expectedException.expect(IllegalStateException.class);
@@ -150,7 +165,7 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void データファイルのベースパスにnullを指定した場合は例外が送出されること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile(null, "record");
 
         expectedException.expect(IllegalStateException.class);
@@ -161,10 +176,10 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void データファイルが空の場合は例外が送出されないこと() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile("record");
 
-        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"));
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8);
 
         assertTrue(dataFile.exists());
         assertFalse(sut.hasNext(new ExecutionContext()));
@@ -172,11 +187,11 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void バッファーを使用しない場合でもデータを読み込めること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile("record")
                 .setUseBuffer(false);
 
-        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
                 "年齢,氏名",
                 "20,山田太郎",
                 "30,鈴木次郎",
@@ -202,11 +217,11 @@ public class DataBindRecordReaderTest {
 
     @Test
     public void バッファーサイズを変更してもデータを読み込めること() throws Exception {
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile("record")
                 .setBufferSize(10);
 
-        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
                 "年齢,氏名",
                 "20,山田太郎",
                 "30,鈴木次郎",
@@ -234,7 +249,7 @@ public class DataBindRecordReaderTest {
     public void 不正なバッファーサイズ指定時には例外が発生すること() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("buffer size was invalid. buffer size must be greater than 0.");
-        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+        sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile("record")
                 .setBufferSize(0);
     }

--- a/src/test/java/nablarch/fw/reader/DataBindRecordReaderTest.java
+++ b/src/test/java/nablarch/fw/reader/DataBindRecordReaderTest.java
@@ -1,6 +1,8 @@
 package nablarch.fw.reader;
 
+import nablarch.common.databind.ObjectMapperFactory;
 import nablarch.fw.ExecutionContext;
+import nablarch.fw.SynchronizedDataReaderWrapper;
 import nablarch.fw.TestSupport;
 import nablarch.test.support.SystemRepositoryResource;
 import org.junit.After;
@@ -9,12 +11,21 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -252,5 +263,43 @@ public class DataBindRecordReaderTest {
         sut = new DataBindRecordReader<>(DataBindTestForm.class)
                 .setDataFile("record")
                 .setBufferSize(0);
+    }
+
+    @Test
+    public void synchronizedでラップした場合_スレッドセーフな挙動となっていること() throws Exception {
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子",
+                "50,田中一郎"
+        );
+
+        // synchronizedでラップしたデータリーダの作成
+        sut = new DataBindRecordReader<>(DataBindTestForm.class);
+        sut.setObjectMapperIterator(new SleepingObjectMapperIterator<>(
+                ObjectMapperFactory.create(DataBindTestForm.class, new FileInputStream(dataFile)),
+                500));
+        SynchronizedDataReaderWrapper<DataBindTestForm> testReader = new SynchronizedDataReaderWrapper<>(sut);
+
+        // 並列実行するタスクを作成
+        List<DataReadTask<DataBindTestForm>> tasks = new ArrayList<>(4);
+        DataReadTask<DataBindTestForm> task = new DataReadTask<>(testReader, new CountDownLatch(4), new ExecutionContext());
+        for (int i = 0; i < 4; i++) {
+            tasks.add(task);
+        }
+
+        // 並列実行し、結果を取得
+        // DataReadTaskのラッチ機構で各スレッドのread()呼出タイミングを同期し、更にread()内で一定時間待つことで実行タイミングを重複させる。
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        List<Future<DataBindTestForm>> result = executor.invokeAll(tasks);
+
+        List<String> actualList = new ArrayList<>();
+        for (Future<DataBindTestForm> future : result) {
+            actualList.add(future.get().getName());
+        }
+
+        assertThat(actualList, hasItems("山田太郎","鈴木次郎","佐藤花子","田中一郎"));
     }
 }

--- a/src/test/java/nablarch/fw/reader/DataBindRecordReaderTest.java
+++ b/src/test/java/nablarch/fw/reader/DataBindRecordReaderTest.java
@@ -1,0 +1,241 @@
+package nablarch.fw.reader;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.TestSupport;
+import nablarch.test.support.SystemRepositoryResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class DataBindRecordReaderTest {
+
+    @Rule
+    public final SystemRepositoryResource resource = new SystemRepositoryResource(
+            "nablarch/fw/reader/DataBindReaderTest.xml");
+
+    @SuppressWarnings("deprecation")
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private final File dataFile = new File(System.getProperty("java.io.tmpdir"), "record.csv");
+
+    private DataBindRecordReader<DataBindTestForm> sut = null;
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @After
+    public void tearDown() throws Exception {
+        if (sut != null) {
+            sut.close(new ExecutionContext());
+        }
+
+        if (dataFile.exists()) {
+            dataFile.delete();
+        }
+    }
+
+    @Test
+    public void ファイルを読み込めること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                        .setDataFile("record");
+
+        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertTrue(sut.hasNext(ctx));
+        DataBindTestForm form = sut.read(ctx);
+        assertEquals(20, form.getAge().intValue());
+        assertEquals("山田太郎", form.getName());
+        assertEquals(2, form.getLineNumber());
+
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(3, sut.read(ctx).getLineNumber());
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(4, sut.read(ctx).getLineNumber());
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
+    public void hasNextなしでreadを呼び出した場合もファイルを読み込めること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                        .setDataFile("record");
+
+        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        DataBindTestForm form = sut.read(ctx);
+        assertEquals(20, form.getAge().intValue());
+        assertEquals("山田太郎", form.getName());
+        assertEquals(2, form.getLineNumber());
+
+        assertEquals(3, sut.read(ctx).getLineNumber());
+        assertEquals(4, sut.read(ctx).getLineNumber());
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
+    public void 初期化前にcloseを呼び出した場合は例外が送出されないこと() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                        .setDataFile("record");
+        sut.close(new ExecutionContext());
+    }
+
+    @Test
+    public void データファイルが存在しない場合は例外が送出されること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                .setDataFile("record");
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectCause(allOf(
+                instanceOf(FileNotFoundException.class),
+                hasProperty("message", containsString("/tmp/record.csv"))
+        ));
+
+        assertFalse(dataFile.exists());
+        sut.hasNext(new ExecutionContext());
+    }
+
+    @Test
+    public void データファイルを指定しない場合は例外が送出されること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class);
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("data file name was blank. data file name must not be blank.");
+
+        sut.hasNext(new ExecutionContext());
+    }
+
+    @Test
+    public void データファイルにnullを指定した場合は例外が送出されること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                .setDataFile(null);
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("data file name was blank. data file name must not be blank.");
+
+        sut.hasNext(new ExecutionContext());
+    }
+
+    @Test
+    public void データファイルのベースパスにnullを指定した場合は例外が送出されること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                .setDataFile(null, "record");
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("data file base path name was blank. data file base path name must not be blank.");
+
+        sut.hasNext(new ExecutionContext());
+    }
+
+    @Test
+    public void データファイルが空の場合は例外が送出されないこと() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                .setDataFile("record");
+
+        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"));
+
+        assertTrue(dataFile.exists());
+        assertFalse(sut.hasNext(new ExecutionContext()));
+    }
+
+    @Test
+    public void バッファーを使用しない場合でもデータを読み込めること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setUseBuffer(false);
+
+        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertTrue(sut.hasNext(ctx));
+        DataBindTestForm form = sut.read(ctx);
+        assertEquals(20, form.getAge().intValue());
+        assertEquals("山田太郎", form.getName());
+        assertEquals(2, form.getLineNumber());
+
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(3, sut.read(ctx).getLineNumber());
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(4, sut.read(ctx).getLineNumber());
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+
+    }
+
+    @Test
+    public void バッファーサイズを変更してもデータを読み込めること() throws Exception {
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setBufferSize(10);
+
+        TestSupport.createFile(dataFile, "\r\n", Charset.forName("UTF-8"),
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertTrue(sut.hasNext(ctx));
+        DataBindTestForm form = sut.read(ctx);
+        assertEquals(20, form.getAge().intValue());
+        assertEquals("山田太郎", form.getName());
+        assertEquals(2, form.getLineNumber());
+
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(3, sut.read(ctx).getLineNumber());
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(4, sut.read(ctx).getLineNumber());
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+
+    }
+
+    @Test
+    public void 不正なバッファーサイズ指定時には例外が発生すること() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("buffer size was invalid. buffer size must be greater than 0.");
+        sut = new DataBindRecordReader<DataBindTestForm>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setBufferSize(0);
+    }
+}

--- a/src/test/java/nablarch/fw/reader/DataBindTestForm.java
+++ b/src/test/java/nablarch/fw/reader/DataBindTestForm.java
@@ -2,11 +2,18 @@ package nablarch.fw.reader;
 
 import nablarch.common.databind.LineNumber;
 import nablarch.common.databind.csv.Csv;
+import nablarch.core.validation.ee.NumberRange;
+import nablarch.core.validation.ee.SystemChar;
 
 @Csv(type = Csv.CsvType.DEFAULT, properties = {"age", "name"}, headers = {"年齢", "氏名"})
 public class DataBindTestForm {
+
+    @NumberRange(min = 0, max = 150, message = "年齢が不正です。")
     private Integer age;
+
+    @SystemChar(charsetDef = "全角文字", message = "氏名は全角文字で入力してください。")
     private String name;
+
     private long lineNumber;
 
     public Integer getAge() {

--- a/src/test/java/nablarch/fw/reader/DataBindTestForm.java
+++ b/src/test/java/nablarch/fw/reader/DataBindTestForm.java
@@ -1,0 +1,37 @@
+package nablarch.fw.reader;
+
+import nablarch.common.databind.LineNumber;
+import nablarch.common.databind.csv.Csv;
+
+@Csv(type = Csv.CsvType.DEFAULT, properties = {"age", "name"}, headers = {"年齢", "氏名"})
+public class DataBindTestForm {
+    private Integer age;
+    private String name;
+    private long lineNumber;
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @LineNumber
+    public long getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(long lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+}

--- a/src/test/java/nablarch/fw/reader/DataReadTask.java
+++ b/src/test/java/nablarch/fw/reader/DataReadTask.java
@@ -5,7 +5,6 @@ import nablarch.fw.ExecutionContext;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /**
  * リーダからデータをリードし、リードした値を返却するタスク。

--- a/src/test/java/nablarch/fw/reader/DataReadTask.java
+++ b/src/test/java/nablarch/fw/reader/DataReadTask.java
@@ -1,0 +1,34 @@
+package nablarch.fw.reader;
+
+import nablarch.fw.DataReader;
+import nablarch.fw.ExecutionContext;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * リーダからデータをリードし、リードした値を返却するタスク。
+ * {@link CountDownLatch}を使用して、{@link DataReader#read(ExecutionContext)}を同期的に呼び出す。
+ */
+public class DataReadTask<T> implements Callable<T> {
+
+    private final DataReader<T> reader;
+
+    private final CountDownLatch latch;
+
+    private final ExecutionContext ctx;
+
+    public DataReadTask(DataReader<T> reader, CountDownLatch latch, ExecutionContext ctx) {
+        this.reader = reader;
+        this.latch = latch;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public T call() throws Exception {
+        latch.countDown();
+        latch.await();
+        return reader.read(ctx);
+    }
+}

--- a/src/test/java/nablarch/fw/reader/DatabaseTableQueueReaderTest.java
+++ b/src/test/java/nablarch/fw/reader/DatabaseTableQueueReaderTest.java
@@ -12,7 +12,11 @@ import static org.junit.Assert.fail;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import nablarch.core.db.connection.ConnectionFactory;
 import nablarch.core.db.connection.TransactionManagerConnection;

--- a/src/test/java/nablarch/fw/reader/DatabaseTableQueueReaderTest.java
+++ b/src/test/java/nablarch/fw/reader/DatabaseTableQueueReaderTest.java
@@ -1,16 +1,18 @@
 package nablarch.fw.reader;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 import nablarch.core.db.connection.ConnectionFactory;
 import nablarch.core.db.connection.TransactionManagerConnection;
@@ -18,6 +20,7 @@ import nablarch.core.db.statement.SqlPStatement;
 import nablarch.core.db.statement.SqlRow;
 import nablarch.core.db.statement.exception.SqlStatementException;
 import nablarch.core.transaction.TransactionContext;
+import nablarch.fw.SynchronizedDataReaderWrapper;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.db.helper.DatabaseTestRunner;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
@@ -39,7 +42,7 @@ public class DatabaseTableQueueReaderTest {
     @Rule
     public SystemRepositoryResource repositoryResource = new SystemRepositoryResource("db-default.xml");
 
-    private static TransactionManagerConnection connection;
+    private TransactionManagerConnection connection;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -146,7 +149,7 @@ public class DatabaseTableQueueReaderTest {
 
         // 別スレッドでデータをリード
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<SqlRow> future = executor.submit(new DataReadTask(sut));
+        Future<SqlRow> future = executor.submit(new DataReadTask<>(sut, new CountDownLatch(1), null));
         executor.shutdown();
         SqlRow row = future.get();
         assertThat("子スレッド側でデータが読み込めていること", row.getBigDecimal("id")
@@ -169,18 +172,18 @@ public class DatabaseTableQueueReaderTest {
 
         // 別スレッドでデータをリード
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<SqlRow> future = executor.submit(new DataReadTask(sut));
+        Future<SqlRow> future = executor.submit(new DataReadTask<>(sut, new CountDownLatch(1), null));
         assertThat("子スレッド側でデータが読み込めること", future.get()
                                                .getBigDecimal("id")
                                                .intValue(), is(1));
 
-        future = executor.submit(new DataReadTask(sut));
+        future = executor.submit(new DataReadTask<>(sut, new CountDownLatch(1), null));
         assertThat("子スレッドで再度リードした場合同じレコードが読み込めること", future.get()
                                                           .getBigDecimal("id")
                                                           .intValue(), is(1));
 
         updateStatus();
-        future = executor.submit(new DataReadTask(sut));
+        future = executor.submit(new DataReadTask<>(sut, new CountDownLatch(1), null));
         assertThat("処理済みになった場合は読み取れない", future.get(), is(nullValue()));
         executor.shutdown();
     }
@@ -192,16 +195,25 @@ public class DatabaseTableQueueReaderTest {
     public void multiThreadRead() throws Exception {
         createTestData(5);
 
+        // synchronizedでラップしたデータリーダの作成
+        // 複数スレッドでDataReader#read()の呼出タイミングを重複させて問題なく動作することを確認したいが、
+        // DatabaseRecordReaderでは、DataReader#read()の呼出タイミングを重複させることができない。
+        // そのため、DataReadTaskのラッチ機構で各スレッドのDataReader#read()呼出タイミングを同期させ、擬似的にread()の実行を重複させている。
         final DatabaseTableQueueReader sut = createReader();
-        ExecutorService executor = Executors.newFixedThreadPool(5);
+        SynchronizedDataReaderWrapper<SqlRow> testReader = new SynchronizedDataReaderWrapper<>(sut);
 
-        List<Future<SqlRow>> result = new ArrayList<Future<SqlRow>>(5);
-        DataReadTask task = new DataReadTask(sut);
+        // 並列実行するタスクを作成
+        List<DataReadTask<SqlRow>> tasks = new ArrayList<>(5);
+        DataReadTask<SqlRow> task = new DataReadTask<>(testReader, new CountDownLatch(5), null);
         for (int i = 0; i < 5; i++) {
-            result.add(executor.submit(task));
+            tasks.add(task);
         }
 
-        List<Integer> actualList = new ArrayList<Integer>();
+        // 並列実行し、結果を取得
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+        List<Future<SqlRow>> result = executor.invokeAll(tasks);
+
+        List<Integer> actualList = new ArrayList<>();
         for (Future<SqlRow> future : result) {
             actualList.add(future.get()
                                  .getBigDecimal("id")
@@ -215,7 +227,7 @@ public class DatabaseTableQueueReaderTest {
     /**
      * 主キーカラムが複数の場合のテスト。
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void multiplePrimaryKeys() throws Exception {
@@ -245,10 +257,11 @@ public class DatabaseTableQueueReaderTest {
         DatabaseRecordReader reader = new DatabaseRecordReader();
         reader.setStatement(connection.prepareStatement("SELECT * FROM MULTI_PRIMARY_KEY ORDER BY ID"));
         final DatabaseTableQueueReader sut = new DatabaseTableQueueReader(reader, 1000, "id1", "id2");
+        final SynchronizedDataReaderWrapper<SqlRow> testReader = new SynchronizedDataReaderWrapper<>(sut);
 
         ExecutorService executor = Executors.newFixedThreadPool(4);
-        Callable<SqlRow> task = new DataReadTask(sut);
-        List<Future<SqlRow>> result = new ArrayList<Future<SqlRow>>();
+        Callable<SqlRow> task = new DataReadTask<>(testReader, new CountDownLatch(0), null);
+        List<Future<SqlRow>> result = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
             result.add(executor.submit(task));
         }
@@ -266,7 +279,7 @@ public class DatabaseTableQueueReaderTest {
     /**
      * INFOログ読み込んだレコードの主キー情報が出力されていることを確認する。
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void writeInfoLog() throws Exception {
@@ -325,7 +338,7 @@ public class DatabaseTableQueueReaderTest {
     /**
      * 待機時間分待機後にデータが取得できること
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void waitTime() throws Exception {
@@ -363,7 +376,7 @@ public class DatabaseTableQueueReaderTest {
     /**
      * クローズ後にデータを読み取ろうとした場合例外が発生すること
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void close() throws Exception {
@@ -385,7 +398,7 @@ public class DatabaseTableQueueReaderTest {
     /**
      * 指定したプライマリーキーが要求に存在しない場合例外が発生すること。
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void pkWasNotFound() throws Exception {
@@ -407,7 +420,7 @@ public class DatabaseTableQueueReaderTest {
     /**
      * プライマリーキーにnullを指定した場合例外が発生すること
      *
-     * @throws Exception
+     * @throws Exception Exception
      */
     @Test
     public void specifiedPrimaryKeyNull() throws Exception {
@@ -482,7 +495,7 @@ public class DatabaseTableQueueReaderTest {
      *
      * @param dataCount 作成レコード数
      */
-    private static void createTestData(int dataCount) {
+    private void createTestData(int dataCount) {
         createTestData(1, dataCount);
     }
 
@@ -491,7 +504,7 @@ public class DatabaseTableQueueReaderTest {
      *
      * @param dataCount 作成レコード数
      */
-    private static void createTestData(int startCount, int dataCount) {
+    private void createTestData(int startCount, int dataCount) {
         SqlPStatement statement = connection.prepareStatement("INSERT INTO BATCH_REQUEST_TABLE VALUES (?, ?, ?)");
         for (int i = startCount; i <= (startCount + dataCount) - 1; i++) {
             statement.setInt(1, i);
@@ -507,27 +520,10 @@ public class DatabaseTableQueueReaderTest {
     /**
      * 要求データのステータスを全て処理済みに更新する。
      */
-    private static void updateStatus() {
+    private void updateStatus() {
         SqlPStatement statement = connection.prepareStatement("UPDATE BATCH_REQUEST_TABLE SET STATUS = '1'");
         statement.executeUpdate();
         connection.commit();
-    }
-
-    /**
-     * リーダからデータをリードし、リードした値を返却するタスク。
-     */
-    private static class DataReadTask implements Callable<SqlRow> {
-
-        private final DatabaseTableQueueReader reader;
-
-        public DataReadTask(DatabaseTableQueueReader reader) {
-            this.reader = reader;
-        }
-
-        @Override
-        public SqlRow call() throws Exception {
-            return reader.read(null);
-        }
     }
 }
 

--- a/src/test/java/nablarch/fw/reader/ResumePointManagerTest.java
+++ b/src/test/java/nablarch/fw/reader/ResumePointManagerTest.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 
 import nablarch.core.ThreadContext;
 import nablarch.core.db.transaction.SimpleDbTransactionManager;
-import nablarch.core.util.FilePathSetting;
 import nablarch.fw.TestSupport;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.db.helper.DatabaseTestRunner;

--- a/src/test/java/nablarch/fw/reader/SleepingFileRecordReader.java
+++ b/src/test/java/nablarch/fw/reader/SleepingFileRecordReader.java
@@ -1,0 +1,31 @@
+package nablarch.fw.reader;
+
+import nablarch.core.dataformat.DataRecord;
+import nablarch.core.dataformat.FileRecordReader;
+
+import java.io.File;
+
+/**
+ * {@link FileRecordReader#read()}で一定時間待機するために使用する{@link FileRecordReader}。
+ */
+public class SleepingFileRecordReader extends FileRecordReader {
+
+    /**
+     * read()メソッド内での待機時間
+     */
+    private final long sleepTimeMillis;
+
+    public SleepingFileRecordReader(File dataFile, File layoutFile, int bufferSize, long sleepTimeMillis) {
+        super(dataFile, layoutFile, bufferSize);
+        this.sleepTimeMillis = sleepTimeMillis;
+    }
+
+    public DataRecord read() {
+        try {
+            Thread.sleep(sleepTimeMillis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return super.read();
+    }
+}

--- a/src/test/java/nablarch/fw/reader/SleepingObjectMapperIterator.java
+++ b/src/test/java/nablarch/fw/reader/SleepingObjectMapperIterator.java
@@ -1,0 +1,31 @@
+package nablarch.fw.reader;
+
+import nablarch.common.databind.ObjectMapper;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.reader.iterator.ObjectMapperIterator;
+
+/**
+ * {@link DataBindRecordReader#read(ExecutionContext)}で一定時間待機するために使用する{@link ObjectMapperIterator}。
+ * @param <T>
+ */
+public class SleepingObjectMapperIterator<T> extends ObjectMapperIterator<T> {
+
+    /**
+     * read()メソッド内での待機時間
+     */
+    private final long sleepTimeMillis;
+
+    public SleepingObjectMapperIterator(ObjectMapper<T> mapper, long sleepTimeMillis) {
+        super(mapper);
+        this.sleepTimeMillis = sleepTimeMillis;
+    }
+
+    public T next() {
+        try {
+            Thread.sleep(sleepTimeMillis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return super.next();
+    }
+}

--- a/src/test/java/nablarch/fw/reader/ValidatableDataBindRecordReaderTest.java
+++ b/src/test/java/nablarch/fw/reader/ValidatableDataBindRecordReaderTest.java
@@ -1,0 +1,322 @@
+package nablarch.fw.reader;
+
+import nablarch.common.databind.ObjectMapper;
+import nablarch.common.databind.ObjectMapperFactory;
+import nablarch.core.message.ApplicationException;
+import nablarch.core.validation.ee.ValidatorUtil;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Result;
+import nablarch.fw.TestSupport;
+import nablarch.fw.reader.iterator.ObjectMapperIterator;
+import nablarch.test.support.SystemRepositoryResource;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class ValidatableDataBindRecordReaderTest {
+
+    @Rule
+    public final SystemRepositoryResource resource = new SystemRepositoryResource(
+            "nablarch/fw/reader/DataBindReaderTest.xml");
+
+    private final File dataFile = new File(System.getProperty("java.io.tmpdir"), "record.csv");
+
+    private ValidatableDataBindRecordReader<DataBindTestForm> sut = null;
+
+    private final ValidatableDataBindRecordReader.DataBindFileValidatorAction<DataBindTestForm> validatorAction =
+            new ValidatableDataBindRecordReader.DataBindFileValidatorAction<>() {
+                @Override
+                public Object handle(DataBindTestForm dataBindTestForm, ExecutionContext executionContext) {
+                    ValidatorUtil.validate(dataBindTestForm);
+                    return new Result.Success();
+                }
+
+                @Override
+                public void onFileEnd(ExecutionContext ctx) {
+                    // nop
+                }
+            };
+
+    private final ValidatableDataBindRecordReader.DataBindFileValidatorAction<DataBindTestForm> errorAction =
+            new ValidatableDataBindRecordReader.DataBindFileValidatorAction<>() {
+                @Override
+                public void onFileEnd(ExecutionContext ctx) {
+                    // nop
+                }
+
+                @Override
+                public Object handle(DataBindTestForm dataBindTestForm, ExecutionContext context) {
+                    throw new OutOfMemoryError();
+                }
+            };
+
+    private static class MockObjectMapperIterator<T> extends ObjectMapperIterator<T> {
+
+        private boolean closed = false;
+
+        public MockObjectMapperIterator(ObjectMapper<T> mapper) {
+            super(mapper);
+        }
+
+        public void close() {
+            if(closed) {
+                return;
+            }
+            closed = true;
+            throw new RuntimeException();
+        }
+
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @After
+    public void tearDown() throws Exception {
+        if (sut != null) {
+            sut.close(new ExecutionContext());
+        }
+
+        if (dataFile.exists()) {
+            dataFile.delete();
+        }
+    }
+
+    @Test
+    public void ファイルからデータを取得できること() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setValidatorAction(validatorAction);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertTrue(sut.hasNext(ctx));
+        DataBindTestForm form = sut.read(ctx);
+        assertEquals(20, form.getAge().intValue());
+        assertEquals("山田太郎", form.getName());
+        assertEquals(2, form.getLineNumber());
+
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(3, sut.read(ctx).getLineNumber());
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(4, sut.read(ctx).getLineNumber());
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+
+    }
+
+    @Test
+    public void キャッシュからデータを取得できること() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setValidatorAction(validatorAction)
+                .setUseCache(true);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertTrue(sut.hasNext(ctx));
+        DataBindTestForm form = sut.read(ctx);
+        assertEquals(20, form.getAge().intValue());
+        assertEquals("山田太郎", form.getName());
+        assertEquals(2, form.getLineNumber());
+
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(3, sut.read(ctx).getLineNumber());
+        assertTrue(sut.hasNext(ctx));
+        assertEquals(4, sut.read(ctx).getLineNumber());
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
+    public void バリデーション失敗時はデータを取得できないこと() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setValidatorAction(validatorAction);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "200,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertThrows(ApplicationException.class, () -> sut.read(ctx));
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
+    public void バリデーションでError発生時はデータを取得できないこと() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setValidatorAction(errorAction);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertThrows(OutOfMemoryError.class, () -> sut.read(ctx));
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
+    public void バリデーションでError発生時_更に例外が発生した場合は最初に発生したErrorが創出されること() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setValidatorAction(errorAction);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        sut.setObjectMapperIterator(new MockObjectMapperIterator<>(ObjectMapperFactory.create(DataBindTestForm.class, new FileInputStream(dataFile))));
+
+        assertThrows(OutOfMemoryError.class, () -> sut.read(new ExecutionContext()));
+    }
+
+    @Test
+    public void キャッシュ有効時_close済みのデータリーダにアクセスしても例外が発生しないこと() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setValidatorAction(validatorAction)
+                .setUseCache(true);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        sut.read(ctx);
+        sut.close(ctx);
+
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
+    public void キャッシュ無効時_close済みのデータリーダにアクセスしても例外が発生しないこと() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setValidatorAction(validatorAction);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        sut.read(ctx);
+        sut.close(ctx);
+
+        assertFalse(sut.hasNext(ctx));
+        assertNull(sut.read(ctx));
+    }
+
+    @Test
+    public void ValidatorActionを設定しない場合_例外が発生すること() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record");
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        IllegalStateException result = assertThrows(IllegalStateException.class, () -> sut.read(new ExecutionContext()));
+        assertEquals("FileValidatorAction was not set. an Object that implements the validation logic must be set.", result.getMessage());
+    }
+
+    @Test
+    public void ValidatorActionにnullを設定する場合_例外が発生すること() throws Exception {
+        IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
+                () -> new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                        .setDataFile("record")
+                        .setValidatorAction(null));
+        assertEquals("validator action was null. validator action must not be null.", result.getMessage());
+    }
+
+    @Test
+    public void バッファーを使用しない場合でもデータを読み込めること() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setUseBuffer(false)
+                .setValidatorAction(validatorAction);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertTrue(sut.hasNext(ctx));
+        assertNotNull(sut.read(ctx));
+    }
+
+    @Test
+    public void バッファーサイズを変更してもデータを読み込めること() throws Exception {
+        sut = new ValidatableDataBindRecordReader<>(DataBindTestForm.class)
+                .setDataFile("record")
+                .setBufferSize(10)
+                .setValidatorAction(validatorAction);
+
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8,
+                "年齢,氏名",
+                "20,山田太郎",
+                "30,鈴木次郎",
+                "40,佐藤花子"
+        );
+
+        ExecutionContext ctx = new ExecutionContext();
+
+        assertTrue(sut.hasNext(ctx));
+        assertNotNull(sut.read(ctx));
+    }
+}

--- a/src/test/java/nablarch/fw/reader/iterator/ObjectMapperIteratorTest.java
+++ b/src/test/java/nablarch/fw/reader/iterator/ObjectMapperIteratorTest.java
@@ -1,0 +1,56 @@
+package nablarch.fw.reader.iterator;
+
+import nablarch.common.databind.ObjectMapperFactory;
+import nablarch.fw.TestSupport;
+import nablarch.fw.reader.DataBindTestForm;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+/**
+ * 本クラスでは、{@link ObjectMapperIterator}のメソッドのうち、他クラスのテストで動作確認できていないものをテストする。
+ */
+@SuppressWarnings("NonAsciiCharacters")
+public class ObjectMapperIteratorTest {
+
+    private final File dataFile = new File(System.getProperty("java.io.tmpdir"), "record.csv");
+
+    private ObjectMapperIterator<DataBindTestForm> sut = null;
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @After
+    public void tearDown() throws Exception {
+        if (sut != null) {
+            sut.close();
+        }
+
+        if (dataFile.exists()) {
+            dataFile.delete();
+        }
+    }
+
+    @Test
+    public void クローズ済みの場合_次のデータはnullになること() throws Exception {
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8);
+
+        sut = new ObjectMapperIterator<>(ObjectMapperFactory.create(DataBindTestForm.class, new FileInputStream(dataFile)));
+
+        sut.close();
+        assertNull(sut.next());
+    }
+
+    @Test
+    public void removeメソッドはサポートされていないこと() throws Exception {
+        TestSupport.createFile(dataFile, "\r\n", StandardCharsets.UTF_8);
+
+        sut = new ObjectMapperIterator<>(ObjectMapperFactory.create(DataBindTestForm.class, new FileInputStream(dataFile)));
+
+        assertThrows(UnsupportedOperationException.class, () -> sut.remove());
+    }
+
+}

--- a/src/test/resources/nablarch/fw/action/DataBindBatchActionTest.xml
+++ b/src/test/resources/nablarch/fw/action/DataBindBatchActionTest.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration xmlns="http://tis.co.jp/nablarch/component-configuration">
+
+  <!--データベース接続構成 -->
+  <import file="db-default.xml" />
+
+  <!-- 文字集合の設定 -->
+  <import file="nablarch/core/validation/charset-definition.xml"/>
+
+  <component name="filePathSetting" class="nablarch.core.util.FilePathSetting">
+    <property name="fileExtensions">
+      <map>
+        <entry key="input" value="dat" />
+      </map>
+    </property>
+    <property name="basePathSettings">
+      <map>
+        <entry key="input" value="file:${java.io.tmpdir}" />
+        <entry key="output" value="file:${java.io.tmpdir}" />
+      </map>
+    </property>
+  </component>
+
+  <!-- リクエストID抽出の実装 -->
+  <component name="requestIdExtractor" class="nablarch.common.util.ShortRequestIdExtractor" />
+
+  <!-- FileRecordReaderConfigの設定（レジューム機能を使用する） -->
+  <component name="resumePointManager"
+      class="nablarch.fw.reader.ResumePointManager">
+    <property name="tableName" value="BATCH_REQUEST" />
+    <property name="requestIdColumnName" value="REQUEST_ID" />
+    <property name="resumePointColumnName" value="RESUME_POINT" />
+    <property name="resumable" value="true" />
+  </component>
+
+  <!--初期化機能の設定 -->
+  <component name="initializer" class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <component-ref name="resumePointManager" />
+      </list>
+    </property>
+  </component>
+
+
+  <!-- ハンドラーキュー構成 -->
+  <list name="handlerQueue">
+
+    <!-- 終了コードマッピング -->
+    <component class="nablarch.fw.handler.StatusCodeConvertHandler" />
+
+    <!-- 共通エラーハンドラー -->
+    <component class="nablarch.fw.handler.GlobalErrorHandler" />
+
+    <!-- スレッドコンテキスト管理ハンドラ-->
+    <component class="nablarch.common.handler.threadcontext.ThreadContextHandler">
+      <property name="attributes">
+        <list>
+          <!-- ユーザID -->
+          <component class="nablarch.common.handler.threadcontext.UserIdAttribute">
+            <property name="sessionKey" value="user.id" />
+            <property name="anonymousId" value="9999999999" />
+          </component>
+          <!-- リクエストID -->
+          <component class="nablarch.common.handler.threadcontext.RequestIdAttribute" />
+          <!-- 言語 -->
+          <component class="nablarch.common.handler.threadcontext.LanguageAttribute">
+            <property name="defaultLanguage" value="ja" />
+          </component>
+          <!-- 実行時ID -->
+          <component class="nablarch.common.handler.threadcontext.ExecutionIdAttribute" />
+        </list>
+      </property>
+    </component>
+
+    <!-- データベース接続管理ハンドラ-->
+    <component
+        name="dbConnectionManagementHandler"
+        class="nablarch.common.handler.DbConnectionManagementHandler">
+    </component>
+
+    <!-- 業務アクションディスパッチハンドラ -->
+    <component class="nablarch.fw.handler.RequestPathJavaPackageMapping">
+      <property name="basePackage" value="nablarch.fw.action" />
+      <property name="immediate" value="false" />
+    </component>
+
+    <!-- マルチスレッド実行制御ハンドラ -->
+    <component class="nablarch.fw.handler.MultiThreadExecutionHandler">
+      <property name="concurrentNumber" value="1" />
+      <property name="terminationTimeout" value="600" />
+    </component>
+
+    <!-- データベース接続管理ハンドラ-->
+    <component class="nablarch.common.handler.DbConnectionManagementHandler">
+    </component>
+
+    <!-- ループハンドラ -->
+    <component class="nablarch.fw.handler.LoopHandler" />
+
+    <!-- テスト用ハンドラ -->
+    <component class="nablarch.test.support.handler.CatchingHandler" />
+
+    <!-- データリードハンドラ -->
+    <component class="nablarch.fw.handler.DataReadHandler">
+    </component>
+
+  </list>
+  <!-- ハンドラーキュー構成(END) -->
+</component-configuration>

--- a/src/test/resources/nablarch/fw/action/DataBindBatchActionTestLoop.xml
+++ b/src/test/resources/nablarch/fw/action/DataBindBatchActionTestLoop.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration xmlns="http://tis.co.jp/nablarch/component-configuration">
+
+  <!--データベース接続構成 -->
+  <import file="db-default.xml" />
+
+  <!-- 文字集合の設定 -->
+  <import file="nablarch/core/validation/charset-definition.xml"/>
+
+  <component name="filePathSetting" class="nablarch.core.util.FilePathSetting">
+    <property name="fileExtensions">
+      <map>
+        <entry key="input" value="dat" />
+      </map>
+    </property>
+    <property name="basePathSettings">
+      <map>
+        <entry key="input" value="file:${java.io.tmpdir}" />
+        <entry key="output" value="file:${java.io.tmpdir}" />
+      </map>
+    </property>
+  </component>
+
+  <!-- リクエストID抽出の実装 -->
+  <component name="requestIdExtractor" class="nablarch.common.util.ShortRequestIdExtractor" />
+
+  <!-- FileRecordReaderConfigの設定（レジューム機能を使用する） -->
+  <component name="resumePointManager"
+      class="nablarch.fw.reader.ResumePointManager">
+    <property name="tableName" value="BATCH_REQUEST" />
+    <property name="requestIdColumnName" value="REQUEST_ID" />
+    <property name="resumePointColumnName" value="RESUME_POINT" />
+    <property name="resumable" value="true" />
+  </component>
+
+  <!--初期化機能の設定 -->
+  <component name="initializer" class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <component-ref name="resumePointManager" />
+      </list>
+    </property>
+  </component>
+
+
+  <!-- ハンドラーキュー構成 -->
+  <list name="handlerQueue">
+
+    <!-- 終了コードマッピング -->
+    <component class="nablarch.fw.handler.StatusCodeConvertHandler" />
+
+    <!-- 共通エラーハンドラー -->
+    <component class="nablarch.fw.handler.GlobalErrorHandler" />
+
+    <!-- スレッドコンテキスト管理ハンドラ-->
+    <component class="nablarch.common.handler.threadcontext.ThreadContextHandler">
+      <property name="attributes">
+        <list>
+          <!-- ユーザID -->
+          <component class="nablarch.common.handler.threadcontext.UserIdAttribute">
+            <property name="sessionKey" value="user.id" />
+            <property name="anonymousId" value="9999999999" />
+          </component>
+          <!-- リクエストID -->
+          <component class="nablarch.common.handler.threadcontext.RequestIdAttribute" />
+          <!-- 言語 -->
+          <component class="nablarch.common.handler.threadcontext.LanguageAttribute">
+            <property name="defaultLanguage" value="ja" />
+          </component>
+          <!-- 実行時ID -->
+          <component class="nablarch.common.handler.threadcontext.ExecutionIdAttribute" />
+        </list>
+      </property>
+    </component>
+
+    <!-- データベース接続管理ハンドラ-->
+    <component
+        name="dbConnectionManagementHandler"
+        class="nablarch.common.handler.DbConnectionManagementHandler">
+    </component>
+
+    <!-- 業務アクションディスパッチハンドラ -->
+    <component class="nablarch.fw.handler.RequestPathJavaPackageMapping">
+      <property name="basePackage" value="nablarch.fw.action" />
+      <property name="immediate" value="false" />
+    </component>
+
+    <!-- マルチスレッド実行制御ハンドラ -->
+    <component class="nablarch.fw.handler.MultiThreadExecutionHandler">
+      <property name="concurrentNumber" value="1" />
+      <property name="terminationTimeout" value="600" />
+    </component>
+
+    <!-- データベース接続管理ハンドラ-->
+    <component class="nablarch.common.handler.DbConnectionManagementHandler">
+    </component>
+
+    <!-- ループハンドラ -->
+    <component class="nablarch.fw.handler.LoopHandler">
+      <property name="commitInterval" value="3"/>
+    </component>
+
+    <!-- テスト用ハンドラ -->
+    <component class="nablarch.test.support.handler.CatchingHandler" />
+
+    <!-- データリードハンドラ -->
+    <component class="nablarch.fw.handler.DataReadHandler">
+    </component>
+
+  </list>
+  <!-- ハンドラーキュー構成(END) -->
+</component-configuration>

--- a/src/test/resources/nablarch/fw/reader/DataBindReaderTest.xml
+++ b/src/test/resources/nablarch/fw/reader/DataBindReaderTest.xml
@@ -4,6 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
 
+  <!-- 文字集合の設定 -->
+  <import file="nablarch/core/validation/charset-definition.xml"/>
+
   <!-- ObjectMapperFactoryの設定 -->
   <component name="objectMapperFactory" class="nablarch.common.databind.BasicObjectMapperFactory" />
 

--- a/src/test/resources/nablarch/fw/reader/DataBindReaderTest.xml
+++ b/src/test/resources/nablarch/fw/reader/DataBindReaderTest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+    xmlns="http://tis.co.jp/nablarch/component-configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration">
+
+  <!-- ObjectMapperFactoryの設定 -->
+  <component name="objectMapperFactory" class="nablarch.common.databind.BasicObjectMapperFactory" />
+
+  <component name="filePathSetting" class="nablarch.core.util.FilePathSetting">
+    <property name="fileExtensions">
+      <map>
+        <entry key="input" value="csv" />
+      </map>
+    </property>
+    <property name="basePathSettings">
+      <map>
+        <entry key="input" value="file:${java.io.tmpdir}" />
+      </map>
+    </property>
+  </component>
+
+</component-configuration>


### PR DESCRIPTION
- データバインド向けデータリーダを作成しました。
  - データリーダ内で使用する `ObjectMapperIterator` も合わせて作成しました。
- バリデート機能付きデータバインド向けデータリーダを作成しました。
- データバインド向けデータリーダを使用する`BatchAction`を作成しました。
- 各データリーダ・メソッドのシグネチャから`synchronized`を取り除きました。
  - setter等に`synchronized`が付与されているパターンもありますが、データリーダ生成時以外で直接呼ばれることはないため、こちらも併せて取り除いています。
- 上記に対応するテストを追加しました。
  - データリーダのマルチスレッドでの動作を確認するテストを追加しました。

- インスペクションの警告に対応しました。
  - 不要な`synchronized`を削除しました。https://github.com/nablarch/nablarch-fw-batch/pull/15/files#diff-e5b436c1e572ff517497032d784daa669e99c99845322c7f1c7263fb01a5cb85L114
  - Java17言語仕様で有効な記法に変更しました。
  - 不要な`static`の削除、`final`の追加など実施しました。
