### PR TITLE
ResumeDataReaderが内部的にResumePointManagerを使用することを明記

### DIFF
--- a/src/main/java/nablarch/fw/reader/ResumeDataReader.java
+++ b/src/main/java/nablarch/fw/reader/ResumeDataReader.java
@@ -19,6 +19,8 @@ import nablarch.fw.handler.LoopHandler;
  * なお、{@link nablarch.fw.action.FileBatchAction}を継承したバッチ業務アクションを作成する場合は、
  * {@code FileBatchAction}がデフォルトで{@link ValidatableFileDataReader}をラップした{@code ResumeDataReader}を生成するので、
  * アプリケーションプログラマが上記２つのオブジェクトを生成するコードを実装する必要はない。
+ * <p>
+ * また本クラスは内部的に{@link ResumePointManager}を使用するため、{@link ResumePointManager}の設定を行っておくこと。
  *
  * @param <TData> このクラスが読み込んだデータの型
  * @author Masato Inoue


### PR DESCRIPTION
https://github.com/nablarch/nablarch-document/pull/680 の派生。

`ResumePointManager`は初期化が必要であり、`ResumePointManager`のクラスの説明にはその記載があるが、解説書に書かれているのは`ResumeDataReader`のみのためこちらからたどれるようにJavadocを更新。